### PR TITLE
fix

### DIFF
--- a/tools/cami-opal/cami_opal.xml
+++ b/tools/cami-opal/cami_opal.xml
@@ -9,7 +9,7 @@
         mkdir -p output inputs &&
 
         #for $i, $file in enumerate($input_files):
-            ln -s '$file' './inputs/$file.element_identifier' &&
+            ln -s '$file.file' './inputs/$file.file.element_identifier' &&
         #end for
 
         opal.py
@@ -51,8 +51,8 @@
         #if $normalized_unifrac:
             --normalized_unifrac
         #end if
-        #for $i, $bin in enumerate($input_files):
-            'inputs/$bin.element_identifier'
+        #for $i, $file in enumerate($input_files):
+            'inputs/$file.file.element_identifier'
         #end for
     ]]>
     </command>


### PR DESCRIPTION
This fixes the element_identifier error, but a better name for file var should be used.
The env failes still with 
```
ImportError: Pandas requires version '3.1.2' or newer of 'jinja2' (version '3.0.0' currently installed).
```
But https://github.com/bioconda/bioconda-recipes/pull/48148 should fix that